### PR TITLE
Prefill KVM password locally

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -11,6 +11,8 @@ That being said, there are a few other ways your data is used.
 
 This extension takes advantage of [Google Chrome's Storage API](https://developer.chrome.com/docs/extensions/reference/storage/) to locally store minimal state information. This is similar to a [cookie](https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies). This information is for configuration and settings for the extension. Google syncs this information across your various computers and Chrome installations. However, this extension only access this data locally on your machine and does do not transmit it.
 
+The optional KVM password is kept in local extension storage only. It is not synced to other Chrome profiles or devices, and the extension sends it only to the configured KVM login pages to pre-fill their password field.
+
 ## Chrome History API
 
 This extension takes advantage of [Google Chrome's History API](https://developer.chrome.com/docs/extensions/reference/history/) to query for GitHub repositories you have visited in the past and present them as links to visit quickly. This information is not transmitted anywhere.

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -11,6 +11,25 @@ import { getPRs } from '../comms/prs';
 import { storage } from '../storage';
 import { loadQuickLinks } from '../comms/quickLinks';
 
+const KVM_ORIGINS = new Set([
+    'https://will-kvm.tailb1072f.ts.net',
+    'https://192.168.68.67',
+    'http://192.168.68.67',
+]);
+
+void chrome.storage.local.setAccessLevel({ accessLevel: 'TRUSTED_CONTEXTS' });
+
+function isKvmPage(url: string | undefined): boolean {
+    if (!url) {
+        return false;
+    }
+    try {
+        return KVM_ORIGINS.has(new URL(url).origin);
+    } catch {
+        return false;
+    }
+}
+
 chrome.runtime.onMessage.addListener(
     (message: Message, sender, sendResponse) => {
         if (!sender.tab) {
@@ -19,7 +38,13 @@ chrome.runtime.onMessage.addListener(
         }
         const senderTab = makeSenderTab(sender);
         if (message.directive) {
-            if (message.directive === Msg.openExtensions) {
+            if (message.directive === Msg.getKvmPassword) {
+                if (!isKvmPage(sender.url)) {
+                    sendResponse({ password: '' });
+                } else {
+                    storage.getKvmPassword().then(password => sendResponse({ password }));
+                }
+            } else if (message.directive === Msg.openExtensions) {
                 chrome.tabs.create({ url: 'chrome://extensions' });
             } else if (message.directive === Msg.closeCurrentTab) {
                 chrome.tabs.remove(senderTab.id, () => {

--- a/src/comms/messages.ts
+++ b/src/comms/messages.ts
@@ -10,6 +10,7 @@ export const Msg = {
     loadClosedTabCommands: 'loadClosedTabCommands',
     loadCurrentTabs: 'loadCurrentTabs',
     loadQuickLinks: 'loadQuickLinks',
+    getKvmPassword: 'getKvmPassword',
 };
 
 export type Message = {

--- a/src/components/Readme.svelte
+++ b/src/components/Readme.svelte
@@ -15,6 +15,7 @@
     let redditThumbnailSizeIncrement = $state(5);
     let currentRedditThumbnailSize = $state(70);
     let awsProfileNamesCSV = $state('');
+    let kvmPassword = $state('');
     storage.get().then((storage: IStorage) => {
         githubUsername = storage.githubUsername;
         gDoubleTime = storage.gDoubleTime;
@@ -25,6 +26,7 @@
         currentRedditThumbnailSize = storage.currentRedditThumbnailSize;
         awsProfileNamesCSV = storage.awsProfileNamesCSV;
     });
+    storage.getKvmPassword().then(password => kvmPassword = password);
 
     const csvUrlRe = /^[.a-z0-9,_ -]*$/
 
@@ -76,7 +78,21 @@
     const ID_RTSI = 'redditThumbnailSizeIncrement';
     const ID_CRTS = 'currentRedditThumbnailSize';
     const ID_APNCSV = 'awsProfileNamesCSV';
+    const ID_KVM_PASSWORD = 'kvmPassword';
     let vimKeysBlacklistCSVInvalid = $derived(!csvUrlRe.test(vimKeysBlacklistCSV));
+    let kvmPasswordTimer: number;
+    function saveKvmPassword() {
+        clearTimeout(kvmPasswordTimer);
+        void storage.setKvmPassword(kvmPassword);
+    }
+    function handleKvmPasswordInputKey(event: KeyboardEvent) {
+        clearTimeout(kvmPasswordTimer);
+        if (event.key === 'Enter') {
+            saveKvmPassword();
+            return;
+        }
+        kvmPasswordTimer = window.setTimeout(saveKvmPassword, 300);
+    }
     // TODO: Is there a way to just call on scrollSmooth change?
     $effect(() => {
         if (scrollSmooth || !scrollSmooth) {
@@ -208,6 +224,17 @@
                spellcheck="false"
                autocomplete="off"
                placeholder="sema4ai-backend-dev, sema4ai-backend-prod"
+        >
+    </div>
+    <div class="setting-input">
+        <label for={ID_KVM_PASSWORD}>KVM Password:</label>
+        <input id={ID_KVM_PASSWORD}
+               name={ID_KVM_PASSWORD}
+               type="password"
+               bind:value={kvmPassword}
+               onkeydown={handleKvmPasswordInputKey}
+               onblur={saveKvmPassword}
+               autocomplete="off"
         >
     </div>
     <div class="setting-input">

--- a/src/content/kvm.ts
+++ b/src/content/kvm.ts
@@ -1,0 +1,36 @@
+import { Msg } from '../comms/messages';
+import { retryAction } from './utils';
+
+type KvmPasswordResponse = {
+    password?: string;
+};
+
+async function prefillKvmPassword() {
+    let response: KvmPasswordResponse | undefined;
+    try {
+        response = await chrome.runtime.sendMessage({ directive: Msg.getKvmPassword }) as KvmPasswordResponse | undefined;
+    } catch {
+        return;
+    }
+    const password = response?.password || '';
+    if (!password) {
+        return;
+    }
+
+    retryAction(10, 200, () => {
+        const input = document.querySelector<HTMLInputElement>('input#form_item_passwd[type="password"]');
+        if (!input) {
+            return false;
+        }
+        if (input.value) {
+            return true;
+        }
+
+        input.value = password;
+        input.dispatchEvent(new Event('input', { bubbles: true }));
+        input.dispatchEvent(new Event('change', { bubbles: true }));
+        return true;
+    });
+}
+
+void prefillKvmPassword();

--- a/src/manifest.config.ts
+++ b/src/manifest.config.ts
@@ -37,6 +37,14 @@ export default defineManifest(async (env) => ({
             js: ["src/content/replicated-admin.ts"],
             all_frames: true,
         },
+        {
+            matches: [
+                "https://will-kvm.tailb1072f.ts.net/*",
+                "https://192.168.68.67/*",
+                "http://192.168.68.67/*",
+            ],
+            js: ["src/content/kvm.ts"],
+        },
     ],
     background: {
         service_worker: "src/background/index.ts",

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -20,12 +20,20 @@ const defaultStorage: IStorage = {
     awsProfileNamesCSV: 'sema4ai-backend-dev, sema4ai-backend-prod',
 };
 
+const kvmPasswordDefault = { kvmPassword: '' };
+
 export async function resetStorage() {
     await storage.set({ ...defaultStorage });
+    await chrome.storage.local.remove('kvmPassword');
 }
 
 export const storage = {
     get: (): Promise<IStorage> =>
         chrome.storage.sync.get(defaultStorage) as Promise<IStorage>,
     set: (value: IStorage): Promise<void> => chrome.storage.sync.set(value),
+    getKvmPassword: async (): Promise<string> => {
+        const { kvmPassword } = await chrome.storage.local.get(kvmPasswordDefault);
+        return kvmPassword;
+    },
+    setKvmPassword: (kvmPassword: string): Promise<void> => chrome.storage.local.set({ kvmPassword }),
 };

--- a/tests/e2e/extension.spec.ts
+++ b/tests/e2e/extension.spec.ts
@@ -37,10 +37,43 @@ test('loads the built Manifest V3 extension and renders its popup', async ({ con
     const manifest = JSON.parse(await readFile(path.join(extensionPath, 'manifest.json'), 'utf8'));
     expect(manifest.manifest_version).toBe(3);
     expect(manifest.background.service_worker).toBeTruthy();
+    const contentScriptMatches = manifest.content_scripts.flatMap((script: { matches: string[] }) => script.matches);
+    expect(contentScriptMatches).toContain('https://will-kvm.tailb1072f.ts.net/*');
+    expect(contentScriptMatches).toContain('https://192.168.68.67/*');
+    expect(contentScriptMatches).toContain('http://192.168.68.67/*');
 
     const popup = await context.newPage();
     await popup.goto(`chrome-extension://${extensionId}/src/popup/popup.html`);
 
     await expect(popup.getByRole('heading', { name: 'CommandCenter' })).toBeVisible();
     await expect(popup.getByLabel('GitHub Username:')).toBeVisible();
+    const kvmPassword = popup.getByLabel('KVM Password:');
+    await kvmPassword.fill('test-only-kvm-password');
+    await kvmPassword.blur();
+    await expect.poll(() => popup.evaluate(() => chrome.storage.local.get('kvmPassword').then(({ kvmPassword }) => kvmPassword))).toBe('test-only-kvm-password');
+
+    await context.route('https://will-kvm.tailb1072f.ts.net/**', async route => {
+        const hasExistingPassword = new URL(route.request().url()).searchParams.get('state') === 'existing';
+        await route.fulfill({
+            contentType: 'text/html',
+            body: `
+                <input id="form_item_passwd" type="password" value="${hasExistingPassword ? 'already-entered' : ''}">
+                <script>
+                    window.passwordEvents = 0;
+                    document.addEventListener('input', () => window.passwordEvents++);
+                    document.addEventListener('change', () => window.passwordEvents++);
+                </script>
+            `,
+        });
+    });
+
+    const kvmLogin = await context.newPage();
+    await kvmLogin.goto('https://will-kvm.tailb1072f.ts.net/#/');
+    await expect(kvmLogin.locator('#form_item_passwd')).toHaveValue('test-only-kvm-password');
+    await expect.poll(() => kvmLogin.evaluate(() => window.passwordEvents)).toBeGreaterThan(0);
+
+    const existingPasswordLogin = await context.newPage();
+    await existingPasswordLogin.goto('https://will-kvm.tailb1072f.ts.net/?state=existing#/');
+    await expect(existingPasswordLogin.locator('#form_item_passwd')).toHaveValue('already-entered');
+    await expect.poll(() => existingPasswordLogin.evaluate(() => window.passwordEvents)).toBe(0);
 });


### PR DESCRIPTION
The KVM login flow requires entering the same password repeatedly. This adds an opt-in CommandCenter setting that pre-fills only the configured KVM password field without submitting the form.

The password is stored locally rather than in synced settings, restricted to trusted extension contexts, and returned only to the configured KVM origins.

Validation:
- `npm ci`
- `npm run check`
- `npm run build`
- `npm run test:e2e`
- `npm audit --omit=dev --audit-level=high`

The E2E test loads the built extension, persists a synthetic local password, verifies field prefill and input/change events on an intercepted KVM page, and confirms an existing field value is not overwritten.

## Risk signals
<!-- auto-generated by apex pr-risk-signals (deterministic); PR-classifier / maintainability-sensors framing -->

| Signal | Value |
|---|---|
| Lines changed | +141 / -1 (8 files) |
| Auth / security path | no |
| Sandbox / VFS isolation | no |
| Data model / migration | no |
| CI / infra / deploy | no |
| New dependency | no |
| Tests present | yes |
| Docs / config-only | no |
| **Classifier bucket** | **normal** |

_Bucket basis: small, localized change; no high-risk signals._

**Gate verdict:** apex review **recommended**; proof-of-change **recommended OR a documented exception** below (too-simple / low-risk / docs-only).

Proof is the built-extension Playwright scenario: it drives a controlled KVM-origin page, verifies password prefill and DOM events, and confirms it will not overwrite a non-empty field. No live KVM password was used in CI.