### PR TITLE
Auto-click AWS SSO allow-access button after 3s

### DIFF
--- a/src/content/siteScripts.ts
+++ b/src/content/siteScripts.ts
@@ -247,6 +247,10 @@ siteScript('meet.google.com', 'Google Meet', () => {
 });
 
 siteScript('awsapps.com', 'AWS SSO', () => {
+    setTimeout(() => {
+        document.querySelector<HTMLButtonElement>('button[data-testid="allow-access-button"]')?.click();
+    }, 3000);
+
     insertStyle('commandcenter-aws-sso', `
         [data-testid="account-list"] {
             display: flex !important;


### PR DESCRIPTION
Adds a 3-second delayed auto-click of the `allow-access-button` consent button on awsapps.com pages, within the existing AWS SSO site script. No-op on pages without the button.